### PR TITLE
foosoft/jmdict to themoeway/jmdict-go change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ JMDict is a simple library written in Go for parsing the raw data files for the
 [JMnedict](http://www.edrdg.org/enamdict/enamdict_doc.html) (names), and
 [KANJIDIC](http://nihongo.monash.edu/kanjidic2/index.html) (Kanji) dictionaries. As far as I know, these are the only
 publicly available Japanese dictionaries and are therefore used by a variety of tools (including
-[Yomichan-Import](https://foosoft.net/projects/yomichan-import) from this site).
+[Yomitan-Import](https://github.com/themoeway/yomitan-import) from this site).
 
 The XML format used to store dictionary entries and entity data was deceptively annoying to work with, leading to the
-creation of this library. Please see the [documentation page](https://godoc.org/foosoft.net/projects/jmdict) for a
+creation of this library. Please see the [documentation page](https://godoc.org/github.com/themoeway/jmdict-go) for a
 technical overview of how to use this library.
-
-Please import this library from `foosoft.net/projects/jmdict` and not the GitHub path.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# JMDict
+# jmdict-go
 
-JMDict is a simple library written in Go for parsing the raw data files for the
+jmdict-go is a simple library written in Go for parsing the raw data files for the
 [JMDict](http://www.edrdg.org/jmdict/j_jmdict.html) (vocabulary)
 [JMnedict](http://www.edrdg.org/enamdict/enamdict_doc.html) (names), and
 [KANJIDIC](http://nihongo.monash.edu/kanjidic2/index.html) (Kanji) dictionaries. As far as I know, these are the only
-publicly available Japanese dictionaries and are therefore used by a variety of tools (including
-[Yomitan-Import](https://github.com/themoeway/yomitan-import) from this site).
+publicly available Japanese dictionaries and are therefore used by a variety of tools including [Yomitan-Import](https://github.com/themoeway/yomitan-import).
 
 The XML format used to store dictionary entries and entity data was deceptively annoying to work with, leading to the
-creation of this library. Please see the [documentation page](https://godoc.org/github.com/themoeway/jmdict-go) for a
+creation of this library. Please see the [documentation page](https://pkg.go.dev/github.com/themoeway/jmdict-go) for a
 technical overview of how to use this library.

--- a/common.go
+++ b/common.go
@@ -1,4 +1,4 @@
-package jmdict
+package jmdict-go
 
 import (
 	"encoding/xml"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module foosoft.net/projects/jmdict
+module github.com/themoeway/jmdict-go
 
 go 1.18

--- a/jmdict.go
+++ b/jmdict.go
@@ -1,4 +1,4 @@
-package jmdict
+package jmdict-go
 
 import "io"
 

--- a/jmnedict.go
+++ b/jmnedict.go
@@ -1,4 +1,4 @@
-package jmdict
+package jmdict-go
 
 import "io"
 

--- a/kanjidic.go
+++ b/kanjidic.go
@@ -1,4 +1,4 @@
-package jmdict
+package jmdict-go
 
 import "io"
 


### PR DESCRIPTION
Changes package name to jmdict-go and Yomichan to Yomitan.
Package location changed to github.com/themoeway/jmdict-go